### PR TITLE
[bug fix] Fix panic when there is only one entity in dac

### DIFF
--- a/dataavailability/datacommittee/datacommittee.go
+++ b/dataavailability/datacommittee/datacommittee.go
@@ -82,7 +82,7 @@ func (d *Backend) Init() error {
 	if committee != nil {
 		d.committeeMembers = committee.Members
 		if len(committee.Members) > 0 {
-			selectedCommitteeMember = rand.Intn(len(committee.Members) - 1) //nolint:gosec
+			selectedCommitteeMember = rand.Intn(len(committee.Members)) //nolint:gosec
 		}
 	}
 	d.selectedCommitteeMember = selectedCommitteeMember


### PR DESCRIPTION
`rand.Intn` can't take `0` as an argument. This PR fixes a panic when there is only one entity in data committee. 

```
[zkevm-node-sequence-sender-001] panic: invalid argument to Intn
[zkevm-node-sequence-sender-001]
[zkevm-node-sequence-sender-001] goroutine 1 [running]:
[zkevm-node-sequence-sender-001] math/rand.(*Rand).Intn(0x0?, 0x0?)
[zkevm-node-sequence-sender-001] 	/usr/local/go/src/math/rand/rand.go:180 +0x4c
[zkevm-node-sequence-sender-001] math/rand.Intn(0xc00013aaa0?)
[zkevm-node-sequence-sender-001] 	/usr/local/go/src/math/rand/rand.go:453 +0x25
[zkevm-node-sequence-sender-001] github.com/0xPolygonHermez/zkevm-sequence-sender/dataavailability/datacommittee.(*Backend).Init(0xc00013aaa0)
[zkevm-node-sequence-sender-001] 	/src/dataavailability/datacommittee/datacommittee.go:85 +0x7a
[zkevm-node-sequence-sender-001] github.com/0xPolygonHermez/zkevm-sequence-sender/dataavailability.New(...)
[zkevm-node-sequence-sender-001] 	/src/dataavailability/dataavailability.go:20
```