### PR TITLE
Support non-legacy type tx decoding

### DIFF
--- a/.github/workflows/kurtosis-ci.yml
+++ b/.github/workflows/kurtosis-ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 0xPolygon/kurtosis-cdk
-          ref: feat/cdk-erigon-zkevm
+          ref: main
           path: kurtosis-cdk
 
       - name: Install Kurtosis CDK tools
@@ -39,12 +39,12 @@ jobs:
       - name: Configure Kurtosis CDK
         working-directory: ./kurtosis-cdk
         run: |
-          yq -Y --in-place '.args.data_availability_mode = "cdk-validium"' params.yml
-          yq -Y --in-place '.args.zkevm_sequence_sender_image = "zkevm-sequence-sender:local"' params.yml
+          yq -Y --in-place '.args.data_availability_mode = "cdk-validium"' cdk-erigon-sequencer-params.yml
+          yq -Y --in-place '.args.zkevm_sequence_sender_image = "zkevm-sequence-sender:local"' cdk-erigon-sequencer-params.yml
 
       - name: Deploy Kurtosis CDK package
         working-directory: ./kurtosis-cdk
-        run: kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
+        run: kurtosis run --enclave cdk-v1 --args-file cdk-erigon-sequencer-params.yml --image-download always .
 
       - name: Monitor verified batches
         working-directory: ./kurtosis-cdk

--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -1056,7 +1056,7 @@ func (s *SequenceSender) addNewBlockTx(l2Tx *datastream.Transaction) {
 	// New Tx raw
 	tx, err := state.DecodeTx(common.Bytes2Hex(l2Tx.Encoded))
 	if err != nil {
-		log.Fatalf("[SeqSender] error decoding tx!")
+		log.Fatalf("[SeqSender] error decoding tx! %v", err)
 		return
 	}
 

--- a/state/helper.go
+++ b/state/helper.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -173,8 +174,11 @@ func DecodeTx(encodedTx string) (*types.Transaction, error) {
 		return nil, err
 	}
 
+	reader := bytes.NewReader(b)
+	stream := rlp.NewStream(reader, 0)
+
 	tx := new(types.Transaction)
-	if err := tx.UnmarshalBinary(b); err != nil {
+	if err := tx.DecodeRLP(stream); err != nil {
 		return nil, err
 	}
 	return tx, nil


### PR DESCRIPTION
This fixes a bug where sequence sender panics when the incoming transaction is non-legacy type.

Tested both legacy type and non-legacy type node. 